### PR TITLE
tinymistで0ページ目が描画される問題を修正

### DIFF
--- a/systemB.typ
+++ b/systemB.typ
@@ -366,6 +366,9 @@
 
       #if calc.even(page_here) [
         #text(9pt, weight: "bold", font: "Noto Serif JP")[
+          #if counter(page).get().first() == 0 {
+            return
+          }
           #counter(page).get().first()
           #h(0.05fr)
           #if not flag {


### PR DESCRIPTION
0ページ目だけ例外的に処理を挟むように修正しました．

```Typst
#if counter(page).get().first() == 0 {
  return
}
```